### PR TITLE
feat: mobile transport, X-Real-IP spoof, settings-based multi-watch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -696,3 +696,8 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+# local secrets / scratch (never commit)
+ktmb.token
+proxy.txt
+*.csv

--- a/config/app/config.yaml
+++ b/config/app/config.yaml
@@ -7,6 +7,11 @@ app:
   service: helium
   module: pollee
   version: '1.0'
+  searcher:
+    mode: web
+    apiUrl: 'https://shuttleonline-api.ktmb.com.my'
+    appUrl: 'https://online-api.ktmb.com.my'
+    requestSignature: ''
   populator:
     delay: 0.5
   watcher:

--- a/config/app/schema.json
+++ b/config/app/schema.json
@@ -198,7 +198,48 @@
     },
     "SearcherConfig": {
       "properties": {
+        "apiUrl": {
+          "type": "string"
+        },
+        "appUrl": {
+          "type": "string"
+        },
+        "mode": {
+          "enum": ["mobile", "web"],
+          "type": "string"
+        },
         "proxy": {
+          "type": "string"
+        },
+        "requestSignature": {
+          "type": "string"
+        },
+        "streams": {
+          "items": {
+            "$ref": "#/definitions/StreamConfig"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "StreamConfig": {
+      "properties": {
+        "delay": {
+          "type": "number"
+        },
+        "mode": {
+          "enum": ["mobile", "web"],
+          "type": "string"
+        },
+        "proxy": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "type": {
+          "enum": ["held", "stateless"],
           "type": "string"
         }
       },

--- a/infra/cron_chart/app/config.yaml
+++ b/infra/cron_chart/app/config.yaml
@@ -7,6 +7,11 @@ app:
   service: helium
   module: pollee
   version: '1.0'
+  searcher:
+    mode: web
+    apiUrl: 'https://shuttleonline-api.ktmb.com.my'
+    appUrl: 'https://online-api.ktmb.com.my'
+    requestSignature: ''
   populator:
     delay: 0.5
   watcher:

--- a/infra/cron_chart/app/schema.json
+++ b/infra/cron_chart/app/schema.json
@@ -198,7 +198,48 @@
     },
     "SearcherConfig": {
       "properties": {
+        "apiUrl": {
+          "type": "string"
+        },
+        "appUrl": {
+          "type": "string"
+        },
+        "mode": {
+          "enum": ["mobile", "web"],
+          "type": "string"
+        },
         "proxy": {
+          "type": "string"
+        },
+        "requestSignature": {
+          "type": "string"
+        },
+        "streams": {
+          "items": {
+            "$ref": "#/definitions/StreamConfig"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "StreamConfig": {
+      "properties": {
+        "delay": {
+          "type": "number"
+        },
+        "mode": {
+          "enum": ["mobile", "web"],
+          "type": "string"
+        },
+        "proxy": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "type": {
+          "enum": ["held", "stateless"],
           "type": "string"
         }
       },

--- a/infra/root_chart/app/config.yaml
+++ b/infra/root_chart/app/config.yaml
@@ -7,6 +7,11 @@ app:
   service: helium
   module: pollee
   version: '1.0'
+  searcher:
+    mode: web
+    apiUrl: 'https://shuttleonline-api.ktmb.com.my'
+    appUrl: 'https://online-api.ktmb.com.my'
+    requestSignature: ''
   populator:
     delay: 0.5
   watcher:

--- a/infra/root_chart/app/schema.json
+++ b/infra/root_chart/app/schema.json
@@ -198,7 +198,48 @@
     },
     "SearcherConfig": {
       "properties": {
+        "apiUrl": {
+          "type": "string"
+        },
+        "appUrl": {
+          "type": "string"
+        },
+        "mode": {
+          "enum": ["mobile", "web"],
+          "type": "string"
+        },
         "proxy": {
+          "type": "string"
+        },
+        "requestSignature": {
+          "type": "string"
+        },
+        "streams": {
+          "items": {
+            "$ref": "#/definitions/StreamConfig"
+          },
+          "type": "array"
+        }
+      },
+      "type": "object"
+    },
+    "StreamConfig": {
+      "properties": {
+        "delay": {
+          "type": "number"
+        },
+        "mode": {
+          "enum": ["mobile", "web"],
+          "type": "string"
+        },
+        "proxy": {
+          "type": "string"
+        },
+        "token": {
+          "type": "string"
+        },
+        "type": {
+          "enum": ["held", "stateless"],
           "type": "string"
         }
       },

--- a/src/cli/cli.ts
+++ b/src/cli/cli.ts
@@ -9,11 +9,9 @@ import { AsciiTable3 } from 'ascii-table3';
 import type { Updater } from '../lib/updater.ts';
 import type { Refunder } from '../lib/refunder.ts';
 import type { Reverter } from '../lib/reverter.ts';
-
-interface WatchData {
-  date: string;
-  from: 'JToW' | 'WToJ';
-}
+import type { Streamer, WatchEntry } from '../lib/streamer.ts';
+import type { Authenticator } from '../lib/authenticator.ts';
+import type { From, StreamSpec } from '../domain/interface.ts';
 
 class Cli {
   constructor(
@@ -25,11 +23,71 @@ class Cli {
     private readonly updater: Updater,
     private readonly refunder: Refunder,
     private readonly reverter: Reverter,
+    private readonly streamer: Streamer,
+    private readonly authenticator: Authenticator,
   ) {}
 
   err(message: string): never {
     this.logger.error(message);
     return process.exit(1);
+  }
+
+  // -d targets: array of {date, from}. The "what to poll".
+  private parseTargets(raw: string): { d: Date; from: From }[] {
+    let source: unknown;
+    try {
+      source = JSON.parse(raw);
+    } catch {
+      this.err('Targets (-d) must be valid JSON');
+    }
+    if (!Array.isArray(source)) this.err('Targets (-d) must be a JSON array of {date, from}');
+    return source.map((r, idx) => {
+      if (typeof r !== 'object' || r == null) this.err(`Target #${idx} must be an object`);
+      const o = r as Record<string, unknown>;
+      if (typeof o.date !== 'string') this.err(`Target #${idx}: 'date' is required (dd-mm-yyyy)`);
+      if (o.from !== 'JToW' && o.from !== 'WToJ') this.err(`Target #${idx}: 'from' must be 'JToW' or 'WToJ'`);
+      return { d: this.zincDate.from(o.date), from: o.from };
+    });
+  }
+
+  // -s settings: array of poll configs (no date/from). The "how to poll".
+  private parseSettings(raw: string): StreamSpec[] {
+    let source: unknown;
+    try {
+      source = JSON.parse(raw);
+    } catch {
+      this.err('Settings (-s) must be valid JSON');
+    }
+    if (!Array.isArray(source)) this.err('Settings (-s) must be a JSON array');
+    return source.map((r, idx) => this.validateSetting(r, idx));
+  }
+
+  private validateSetting(r: unknown, idx: number): StreamSpec {
+    if (typeof r !== 'object' || r == null) this.err(`Setting #${idx} must be an object`);
+    const o = r as Record<string, unknown>;
+
+    const mode = o.mode ?? 'web';
+    if (mode !== 'web' && mode !== 'mobile') this.err(`Setting #${idx}: mode must be 'web' or 'mobile'`);
+    const type = o.type ?? 'stateless';
+    if (type !== 'stateless' && type !== 'held') this.err(`Setting #${idx}: type must be 'stateless' or 'held'`);
+    const delay = o.delay ?? 1000;
+    if (typeof delay !== 'number' || !Number.isFinite(delay) || delay < 0)
+      this.err(`Setting #${idx}: delay must be a non-negative number (milliseconds)`);
+    if (o.proxy != null && typeof o.proxy !== 'string' && typeof o.proxy !== 'boolean')
+      this.err(`Setting #${idx}: proxy must be a URL string, true (pool), or false/omitted (direct)`);
+    if (o.token != null && typeof o.token !== 'string') this.err(`Setting #${idx}: token must be a string`);
+    if (o.spoofIp != null && typeof o.spoofIp !== 'boolean') this.err(`Setting #${idx}: spoofIp must be a boolean`);
+    if (mode === 'mobile' && (typeof o.token !== 'string' || o.token.length === 0))
+      this.err(`Setting #${idx}: mobile settings require a 'token' (userData)`);
+
+    return {
+      mode,
+      type,
+      delay,
+      proxy: o.proxy as string | boolean | undefined,
+      token: o.token as string | undefined,
+      spoofIp: o.spoofIp as boolean | undefined,
+    };
   }
 
   async start(): Promise<void> {
@@ -103,34 +161,58 @@ class Cli {
 
     program
       .command('multi-watch')
-      .description('Start repeatedly poll and watch for changes for all days and directions')
-      .option('-d, --data <data>', 'Polling data in JSON')
-      .option('-i, --interval <interval>', 'Interval to poll in seconds, default 180')
-      .action(async ({ data, interval }: { data: string; interval: string }) => {
-        await tracer.startActiveSpan('watch', async span => {
-          if (data == null) this.err("Data is required, -d '[]'");
-          if (interval == null) this.err('Interval is required, -i <seconds>');
+      .description(
+        'Poll targets × settings. -d targets [{date,from}], -s settings [{mode,type,delay,proxy,spoofIp,token}]',
+      )
+      .option('-d, --data <data>', 'JSON array of targets: [{date, from}]')
+      .option('-s, --settings <settings>', 'JSON array of poll settings (cross-producted with targets)')
+      .option('-i, --interval <interval>', 'Total run duration in seconds')
+      .option('--dry-run', 'Log fetched schedules instead of publishing to redis')
+      .action(
+        async ({
+          data,
+          settings,
+          interval,
+          dryRun,
+        }: {
+          data: string;
+          settings: string;
+          interval: string;
+          dryRun?: boolean;
+        }) => {
+          await tracer.startActiveSpan('multi-watch', async span => {
+            if (data == null) this.err('Targets are required, -d \'[{"date":..,"from":..}]\'');
+            if (settings == null) this.err('Settings are required, -s \'[{"mode":..}]\'');
+            if (interval == null) this.err('Interval is required, -i <seconds>');
 
-          const i = Number.parseInt(interval);
+            const i = Number.parseInt(interval);
+            if (Number.isNaN(i)) this.err('Interval must be a number');
 
-          if (Number.isNaN(i)) this.err('Interval must be a number');
+            const targets = this.parseTargets(data);
+            const specs = this.parseSettings(settings);
+            if (targets.length === 0) this.err('No targets provided (-d)');
+            if (specs.length === 0) this.err('No settings provided (-s)');
 
-          const dObj = JSON.parse(data);
-          this.logger.info({ jobData: dObj }, 'Job data');
-          const all: Promise<void>[] = [];
+            // commutative cross product: every target polled by every setting
+            const entries: WatchEntry[] = targets.flatMap(t => specs.map(spec => ({ d: t.d, from: t.from, spec })));
 
-          for (const { date, from } of dObj) {
-            const d = this.zincDate.from(date);
-            if (from !== 'JToW' && from !== 'WToJ') this.err("From must be either 'JToW' or 'WToJ'");
             const now = Date.now();
-            this.logger.info({ date, from, interval }, 'Starting watch');
-            all.push(this.watcher.Watch(d, now, i, from));
-          }
-          await Promise.allSettled(all);
-          span.end();
-        });
-        process.exit(0);
-      });
+            this.logger.info(
+              {
+                targets: targets.length,
+                settings: specs.length,
+                streams: entries.length,
+                interval,
+                dryRun: dryRun ?? false,
+              },
+              'Starting multi-watch',
+            );
+            await this.streamer.Run(entries, now, i * 1000, dryRun ?? false);
+            span.end();
+          });
+          process.exit(0);
+        },
+      );
 
     program
       .command('watch')
@@ -157,6 +239,45 @@ class Cli {
         });
         process.exit(0);
       });
+
+    program
+      .command('login')
+      .description('Log in to KTMB mobile API and write the userData token to a file')
+      .option('-e, --email <email>', 'KTMB account email')
+      .option('-p, --password <password>', 'KTMB account password')
+      .option('-o, --out <out>', 'Output token file, default ktmb.token')
+      .option('--proxy <proxy>', 'Proxy to log in through')
+      .action(
+        async ({
+          email,
+          password,
+          out,
+          proxy,
+        }: {
+          email?: string;
+          password?: string;
+          out?: string;
+          proxy?: string;
+        }) => {
+          if (email == null) this.err('Email is required, -e <email>');
+          if (password == null) this.err('Password is required, -p <password>');
+          const outFile = out ?? 'ktmb.token';
+          try {
+            await this.authenticator.Login(email, password, outFile, proxy);
+          } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            if (/multiple login/i.test(message)) {
+              this.err(
+                'Login failed: this account already has an active KTMB session (only one session per ' +
+                  'account is allowed). Release the existing session (log it out, or use KTMB "Forget ' +
+                  `Password" to reset) and then re-login — or use a different account. Detail: ${message}`,
+              );
+            }
+            this.err(`Login failed: ${message}`);
+          }
+          process.exit(0);
+        },
+      );
 
     await program.parseAsync(process.argv);
   }

--- a/src/config/searcher.config.ts
+++ b/src/config/searcher.config.ts
@@ -1,7 +1,59 @@
-import { IsOptional, IsString, IsUrl } from 'class-validator';
+import { IsBoolean, IsIn, IsNumber, IsOptional, Min, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
+import type { PollType, SearcherMode, StreamSpec } from '../domain/interface';
+
+export class StreamConfig implements StreamSpec {
+  @IsIn(['web', 'mobile'])
+  mode!: SearcherMode;
+
+  @IsIn(['stateless', 'held'])
+  type!: PollType;
+
+  @IsOptional()
+  proxy?: string | boolean;
+
+  @IsNumber()
+  @Min(0)
+  delay!: number;
+
+  @IsString()
+  @IsOptional()
+  token?: string;
+
+  @IsBoolean()
+  @IsOptional()
+  spoofIp?: boolean;
+}
 
 export class SearcherConfig {
+  // `;`-separated proxy pool used by the legacy (random) web paths.
   @IsString()
   @IsOptional()
   proxy?: string;
+
+  // Default transport for the single-poller commands (watch/get/populator).
+  @IsIn(['web', 'mobile'])
+  @IsOptional()
+  mode?: SearcherMode;
+
+  // Static KTMB app key sent on every mobile API call. Global, never per-row.
+  @IsString()
+  @IsOptional()
+  requestSignature?: string;
+
+  // Mobile JSON API host, e.g. https://shuttleonline-api.ktmb.com.my
+  @IsString()
+  @IsOptional()
+  apiUrl?: string;
+
+  // Mobile account API host (login lives here — helium never calls it).
+  @IsString()
+  @IsOptional()
+  appUrl?: string;
+
+  // Optional default stream table; overridable per-invocation via the CLI.
+  @ValidateNested({ each: true })
+  @Type(() => StreamConfig)
+  @IsOptional()
+  streams?: StreamConfig[];
 }

--- a/src/domain/interface.ts
+++ b/src/domain/interface.ts
@@ -16,4 +16,28 @@ interface IFixedScheduleSearcher {
   Search(): Promise<TrainSchedule[]>;
 }
 
-export type { TrainSchedule, IScheduleSearcher, IFixedScheduleSearcher, From };
+type SearcherMode = 'web' | 'mobile';
+
+type PollType = 'stateless' | 'held';
+
+// One row of the deterministic poller table: a single stream's behaviour.
+// Direction and date are shared by the whole run, so they are not part of a stream.
+interface StreamSpec {
+  // Transport: scrape the website ('web') or hit the mobile JSON API ('mobile').
+  mode: SearcherMode;
+  // Caching strategy: re-establish every poll ('stateless') or cache the
+  // expensive token and only poll the cheap endpoint ('held').
+  type: PollType;
+  // Proxy control: a URL string = use that proxy; `true` = use the config proxy
+  // pool (random pick); omit/`false` = direct connection (no proxy).
+  proxy?: string | boolean;
+  // Delay between polls, in milliseconds (the per-stream polling speed).
+  delay: number;
+  // KTMB `userData` token. Required for mobile streams, ignored for web.
+  token?: string;
+  // Send a fresh random X-Real-IP per request to rotate the rate-limit bucket
+  // (KTMB keys its limiter on that header). Default off.
+  spoofIp?: boolean;
+}
+
+export type { TrainSchedule, IScheduleSearcher, IFixedScheduleSearcher, From, SearcherMode, PollType, StreamSpec };

--- a/src/domain/mobile_search_core.ts
+++ b/src/domain/mobile_search_core.ts
@@ -1,0 +1,222 @@
+import moment from 'moment';
+import type { Logger } from 'pino';
+import type { SearcherConfig } from '../config/searcher.config.ts';
+import type { From, TrainSchedule } from './interface.ts';
+import { randomIp } from '../util/random_ip.ts';
+
+// Numeric station ids used by the mobile API (distinct from the web station names).
+const JB_STATION_ID = '37500';
+const WOODLANDS_STATION_ID = '37600';
+
+const DEFAULT_API_URL = 'https://shuttleonline-api.ktmb.com.my';
+const DEFAULT_APP_URL = 'https://online-api.ktmb.com.my';
+
+// Every mobile response is wrapped in this envelope. `status: false` => the
+// `messages` array carries the error.
+interface ApiResponse<T> {
+  status: boolean;
+  messages: string[];
+  messageCode: string | null;
+  data: T;
+}
+
+interface Station {
+  id: string;
+  stationData: string;
+}
+
+interface StationsData {
+  stations: Station[];
+}
+
+interface SearchData {
+  searchData: string;
+}
+
+interface Trip {
+  trainNo: string;
+  serviceCategory: string;
+  departDateTime: string;
+  arrivalDateTime: string;
+  seat: number | string;
+  price: number | string;
+  currency: string;
+  tripData: string;
+}
+
+interface TripData {
+  trips: Trip[];
+}
+
+interface LoginData {
+  email: string;
+  fullName: string;
+  eWalletAmount: number;
+  eWalletCurrency: string;
+  userData: string;
+}
+
+// Map from station id -> opaque `stationData` blob required by Search.
+type StationMap = Map<string, string>;
+
+/**
+ * Mobile counterpart of {@link SearchCore}. Talks to KTMB's mobile JSON API
+ * using a caller-supplied `userData` token + global `requestSignature`.
+ *
+ * It deliberately performs NO login/logout — KTMB allows only one active
+ * session per account, so the token is owned centrally and passed in verbatim.
+ */
+class MobileSearchCore {
+  #config: SearcherConfig;
+  #logger: Logger;
+
+  constructor(config: SearcherConfig, logger: Logger) {
+    this.#config = config;
+    this.#logger = logger;
+  }
+
+  get #apiUrl(): string {
+    return this.#config.apiUrl ?? DEFAULT_API_URL;
+  }
+
+  get #appUrl(): string {
+    return this.#config.appUrl ?? DEFAULT_APP_URL;
+  }
+
+  get #signature(): string {
+    const s = this.#config.requestSignature;
+    if (s == null) throw new Error('requestSignature is required for mobile mode');
+    return s;
+  }
+
+  // Headers common to every mobile call (no session).
+  #baseHeaders(): Record<string, string> {
+    return {
+      'Content-Type': 'application/json',
+      requestSignature: this.#signature,
+    };
+  }
+
+  // Session-scoped headers for shuttle endpoints.
+  #headers(userData: string): Record<string, string> {
+    return { ...this.#baseHeaders(), userData };
+  }
+
+  async #send<T>(url: string, headers: Record<string, string>, body: unknown, proxy?: string): Promise<T> {
+    const init = {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body ?? {}),
+    } as RequestInit;
+    // Bun's fetch supports a `proxy` field that isn't in the DOM lib types.
+    if (proxy) (init as { proxy?: string }).proxy = proxy;
+
+    const resp = await fetch(url, init);
+    const text = await resp.text();
+
+    let parsed: ApiResponse<T>;
+    try {
+      parsed = JSON.parse(text);
+    } catch (e) {
+      this.#logger.info({ text, url }, 'Error parsing mobile response from KTMB');
+      this.#logger.error(e, 'Error parsing mobile response from KTMB');
+      throw e;
+    }
+
+    if (!parsed.status) {
+      throw new Error(`KTMB mobile API error on ${url}: ${JSON.stringify(parsed.messages)}`);
+    }
+    return parsed.data;
+  }
+
+  async #post<T>(path: string, userData: string, body: unknown, proxy?: string, spoofIp = false): Promise<T> {
+    const headers = spoofIp ? { ...this.#headers(userData), 'X-Real-IP': randomIp() } : this.#headers(userData);
+    return this.#send<T>(`${this.#apiUrl}${path}`, headers, body, proxy);
+  }
+
+  // EmailLogin on the account host (appUrl). Returns the `userData` session
+  // token. This is the ONLY place helium authenticates — used by the `login`
+  // command to mint a token, never during polling.
+  async login(email: string, password: string, proxy?: string): Promise<LoginData> {
+    return this.#send<LoginData>(
+      `${this.#appUrl}/v1/account/EmailLogin`,
+      this.#baseHeaders(),
+      { email, password },
+      proxy,
+    );
+  }
+
+  // ISO date the mobile API expects for OnwardDate/DepartDate. Use UTC so a
+  // midnight `Date` doesn't get shifted into the previous/next day.
+  #isoDate(date: Date): string {
+    return moment.utc(date).format('YYYY-MM-DDTHH:mm:ss');
+  }
+
+  async stations(userData: string, proxy?: string, spoofIp = false): Promise<StationMap> {
+    const d = await this.#post<StationsData>('/v1/shuttletrip/Station', userData, {}, proxy, spoofIp);
+    return new Map(d.stations.map(s => [s.id, s.stationData]));
+  }
+
+  async search(
+    userData: string,
+    from: From,
+    date: Date,
+    stations: StationMap,
+    proxy?: string,
+    spoofIp = false,
+  ): Promise<string> {
+    const [fromId, toId] =
+      from === 'JToW' ? [JB_STATION_ID, WOODLANDS_STATION_ID] : [WOODLANDS_STATION_ID, JB_STATION_ID];
+
+    const fromStationData = stations.get(fromId);
+    const toStationData = stations.get(toId);
+    if (fromStationData == null || toStationData == null)
+      throw new Error(`Unable to find station data for direction ${from}`);
+
+    // NB: no ReturnDate — the mobile API rejects an empty string for that
+    // nullable DateTime ("could not be converted to System.Nullable[DateTime]").
+    // tin's SearchReq omits it entirely, so we do too.
+    const body = {
+      FromStationData: fromStationData,
+      FromStationId: fromId,
+      ToStationData: toStationData,
+      ToStationId: toId,
+      OnwardDate: this.#isoDate(date),
+      PassengerCount: 1,
+    };
+
+    const res = await this.#post<SearchData>('/v1/shuttletrip/Search', userData, body, proxy, spoofIp);
+    return res.searchData;
+  }
+
+  async trip(
+    userData: string,
+    date: Date,
+    searchData: string,
+    proxy?: string,
+    spoofIp = false,
+  ): Promise<TrainSchedule[]> {
+    const body = {
+      BookingTripSequenceNo: 1,
+      DepartDate: this.#isoDate(date),
+      searchData,
+    };
+
+    const res = await this.#post<TripData>('/v1/shuttletrip/Trip', userData, body, proxy, spoofIp);
+    return res.trips.map(t => this.#toSchedule(t));
+  }
+
+  // Map a mobile trip into helium's existing TrainSchedule shape so downstream
+  // code (watcher/redis consumers) is identical to the web path.
+  #toSchedule(t: Trip): TrainSchedule {
+    return {
+      train_service: t.trainNo,
+      departure_time: moment.utc(t.departDateTime).format('HH:mm'),
+      arrival_time: moment.utc(t.arrivalDateTime).format('HH:mm'),
+      available_seats: typeof t.seat === 'number' ? t.seat : Number.parseInt(t.seat, 10),
+      min_fare: `${t.currency} ${t.price}`,
+    };
+  }
+}
+
+export { type StationMap, type LoginData, MobileSearchCore };

--- a/src/domain/search_core.ts
+++ b/src/domain/search_core.ts
@@ -5,8 +5,16 @@ import type { Logger } from 'pino';
 import { stringify } from 'node:querystring';
 import type { SearcherConfig } from '../config/searcher.config.ts';
 import type { From, TrainSchedule } from './interface.ts';
+import { randomIp } from '../util/random_ip.ts';
 
+// Optional X-Real-IP header (rotates KTMB's rate-limit bucket when spoofing).
+const realIp = (spoofIp: boolean): Record<string, string> => (spoofIp ? { 'X-Real-IP': randomIp() } : {});
+
+// A cookie-jar-bound fetch. Each web polling session gets its own (see
+// SearchCore.newSession) so concurrent streams don't clobber each other's
+// antiforgery/session cookies in a shared jar.
 const f = fetchCookie(fetch);
+type Fetcher = typeof f;
 
 const htmlHeaders = {
   accept:
@@ -78,18 +86,25 @@ class SearchCore {
     return arr[randomIndex];
   }
 
-  async mainKTMBPage(proxy?: string): Promise<MainPageToken> {
+  // Fresh isolated cookie jar for one web polling session. Pass it through the
+  // main-page → post → trip calls so each stream keeps its own session.
+  newSession(): Fetcher {
+    return fetchCookie(fetch);
+  }
+
+  async mainKTMBPage(proxy?: string, spoofIp = false, fetcher: Fetcher = f): Promise<MainPageToken> {
     const referer = 'https://online.ktmb.com.my/';
     const init = {
       headers: {
         ...defaultHeaders,
         ...htmlHeaders,
         Referer: referer,
+        ...realIp(spoofIp),
       },
-      proxy: proxy || this.proxy,
+      proxy,
       method: 'GET',
     };
-    const resp = await f('https://shuttleonline.ktmb.com.my/Home/Shuttle', init);
+    const resp = await fetcher('https://shuttleonline.ktmb.com.my/Home/Shuttle', init);
     const text = await resp.text();
 
     const $ = cheerio.load(text);
@@ -114,6 +129,8 @@ class SearchCore {
     woodlandToken: string,
     requestVerificationToken: string,
     proxy?: string,
+    spoofIp = false,
+    fetcher: Fetcher = f,
   ): Promise<ProxyToken> {
     const d = moment(date).format('D MMM YYYY');
 
@@ -140,13 +157,14 @@ class SearchCore {
         ...htmlHeaders,
         ...defaultHeaders,
         Referer: referer,
+        ...realIp(spoofIp),
       },
-      proxy: proxy || this.proxy,
+      proxy,
       body: stringify(queryParams),
       method: 'POST',
     };
 
-    const resp = await f('https://shuttleonline.ktmb.com.my/ShuttleTrip', init);
+    const resp = await fetcher('https://shuttleonline.ktmb.com.my/ShuttleTrip', init);
 
     const t = await resp.text();
     const $ = cheerio.load(t);
@@ -167,6 +185,8 @@ class SearchCore {
     formValidation: string,
     date: Date,
     proxy?: string,
+    spoofIp = false,
+    fetcher: Fetcher = f,
   ): Promise<TrainSchedule[]> {
     const DepartDate = moment(date).format('YYYY-MM-DD');
 
@@ -178,8 +198,9 @@ class SearchCore {
         ...defaultHeaders,
         RequestVerificationToken: token,
         Referer: referer,
+        ...realIp(spoofIp),
       },
-      proxy: proxy || this.proxy,
+      proxy,
       body: JSON.stringify({
         SearchData: searchData,
         FormValidationCode: formValidation,
@@ -190,7 +211,7 @@ class SearchCore {
       method: 'POST',
     };
 
-    const r = await f('https://shuttleonline.ktmb.com.my/ShuttleTrip/Trip', init);
+    const r = await fetcher('https://shuttleonline.ktmb.com.my/ShuttleTrip/Trip', init);
 
     let o: TrainScheduleResp | null = null;
     const text = await r.text();
@@ -276,4 +297,4 @@ class SearchCore {
   }
 }
 
-export { type MainPageToken, type ProxyToken, SearchCore };
+export { type MainPageToken, type ProxyToken, type Fetcher, SearchCore };

--- a/src/domain/search_core.ts
+++ b/src/domain/search_core.ts
@@ -10,6 +10,16 @@ import { randomIp } from '../util/random_ip.ts';
 // Optional X-Real-IP header (rotates KTMB's rate-limit bucket when spoofing).
 const realIp = (spoofIp: boolean): Record<string, string> => (spoofIp ? { 'X-Real-IP': randomIp() } : {});
 
+const escapeRegExp = (s: string): string => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+// Pull a hidden <input>'s value by id/name WITHOUT building a full DOM. Much
+// cheaper than cheerio for the handful of tokens we extract from large pages
+// (robust to attribute order and quote style within the tag).
+const inputValue = (html: string, attr: 'id' | 'name', name: string): string | undefined => {
+  const tag = html.match(new RegExp(`<input\\b[^>]*\\b${attr}=["']${escapeRegExp(name)}["'][^>]*>`, 'i'))?.[0];
+  return tag?.match(/\bvalue=["']([^"']*)["']/i)?.[1];
+};
+
 // A cookie-jar-bound fetch. Each web polling session gets its own (see
 // SearchCore.newSession) so concurrent streams don't clobber each other's
 // antiforgery/session cookies in a shared jar.
@@ -107,11 +117,9 @@ class SearchCore {
     const resp = await fetcher('https://shuttleonline.ktmb.com.my/Home/Shuttle', init);
     const text = await resp.text();
 
-    const $ = cheerio.load(text);
-
-    const from = $('#FromStationData').attr('value');
-    const to = $('#ToStationData').attr('value');
-    const token = $('input[name=__RequestVerificationToken]').attr('value');
+    const from = inputValue(text, 'id', 'FromStationData');
+    const to = inputValue(text, 'id', 'ToStationData');
+    const token = inputValue(text, 'name', '__RequestVerificationToken');
 
     if (from == null || to == null || token == null) throw new Error('Unable to find from or to station');
 
@@ -167,10 +175,8 @@ class SearchCore {
     const resp = await fetcher('https://shuttleonline.ktmb.com.my/ShuttleTrip', init);
 
     const t = await resp.text();
-    const $ = cheerio.load(t);
-
-    const searchData = $('#SearchData').attr('value');
-    const formValidationCode = $('#FormValidationCode').attr('value');
+    const searchData = inputValue(t, 'id', 'SearchData');
+    const formValidationCode = inputValue(t, 'id', 'FormValidationCode');
     if (searchData == null || formValidationCode == null)
       throw new Error('Unable to find search data or form validation code');
     return {

--- a/src/domain/searcher/builder.ts
+++ b/src/domain/searcher/builder.ts
@@ -1,32 +1,70 @@
 import type { SearchCore } from '../search_core.ts';
-import type { From, IFixedScheduleSearcher, IScheduleSearcher } from '../interface.ts';
+import type { MobileSearchCore } from '../mobile_search_core.ts';
+import type { From, IFixedScheduleSearcher, IScheduleSearcher, StreamSpec } from '../interface.ts';
 import { StatelessScheduleSearcher } from './stateless_schedule_searcher.ts';
 import { LoadedScheduleSearcher } from './loaded_schedule_searcher.ts';
 import { FixedScheduleSearcher } from './fixed_schedule_searcher.ts';
+import { MobileStatelessScheduleSearcher } from './mobile_stateless_schedule_searcher.ts';
+import { MobileHeldScheduleSearcher } from './mobile_held_schedule_searcher.ts';
 
 class SearcherBuilder {
-  constructor(private readonly searchCore: SearchCore) {}
+  constructor(
+    private readonly searchCore: SearchCore,
+    private readonly mobileCore: MobileSearchCore,
+  ) {}
 
-  async BuildStateless(): Promise<IScheduleSearcher> {
-    const searcher = new StatelessScheduleSearcher(this.searchCore);
-    return Promise.resolve(searcher);
+  // Resolve a stream spec's `proxy` field to a concrete proxy URL (or undefined
+  // = direct). String => that proxy; true => a random pick from the config pool.
+  #resolveProxy(p?: string | boolean): string | undefined {
+    if (typeof p === 'string') return p;
+    if (p === true) return this.searchCore.proxy;
+    return undefined;
   }
 
-  async BuildLoaded(): Promise<IScheduleSearcher> {
-    const token = await this.searchCore.mainKTMBPage();
-    return new LoadedScheduleSearcher(this.searchCore, token);
+  async BuildStateless(): Promise<IScheduleSearcher> {
+    // Legacy path (watch): random proxy from the config pool, per poll.
+    return new StatelessScheduleSearcher(this.searchCore, undefined, false, true);
+  }
+
+  async BuildLoaded(proxy?: string, spoofIp = false, usePool = true): Promise<IScheduleSearcher> {
+    const mainProxy = proxy ?? (usePool ? this.searchCore.proxy : undefined);
+    const session = this.searchCore.newSession();
+    const token = await this.searchCore.mainKTMBPage(mainProxy, spoofIp, session);
+    return new LoadedScheduleSearcher(this.searchCore, token, proxy, spoofIp, usePool, session);
   }
 
   async BuildFixed(from: From, d: Date): Promise<IFixedScheduleSearcher> {
-    const main = await this.searchCore.mainKTMBPage();
+    const netProxy = this.searchCore.proxy;
+    const session = this.searchCore.newSession();
+    const main = await this.searchCore.mainKTMBPage(netProxy, false, session);
     const proxy = await this.searchCore.proxyKTMBPost(
       from,
       d,
       main.JBToken,
       main.WoodlandsToken,
       main.requestVerificationToken,
+      netProxy,
+      false,
+      session,
     );
-    return new FixedScheduleSearcher(this.searchCore, main, proxy, d);
+    return new FixedScheduleSearcher(this.searchCore, main, proxy, d, netProxy, session);
+  }
+
+  // Build the searcher for one row of the deterministic stream table.
+  async BuildForStream(spec: StreamSpec): Promise<IScheduleSearcher> {
+    const spoof = spec.spoofIp ?? false;
+    const proxy = this.#resolveProxy(spec.proxy);
+
+    if (spec.mode === 'mobile') {
+      if (spec.token == null || spec.token.length === 0) throw new Error('mobile stream requires a token (userData)');
+      return spec.type === 'held'
+        ? new MobileHeldScheduleSearcher(this.mobileCore, spec.token, proxy, spoof)
+        : new MobileStatelessScheduleSearcher(this.mobileCore, spec.token, proxy, spoof);
+    }
+
+    return spec.type === 'held'
+      ? await this.BuildLoaded(proxy, spoof, false)
+      : new StatelessScheduleSearcher(this.searchCore, proxy, spoof, false);
   }
 }
 

--- a/src/domain/searcher/fixed_schedule_searcher.ts
+++ b/src/domain/searcher/fixed_schedule_searcher.ts
@@ -1,5 +1,5 @@
 import type { IFixedScheduleSearcher, TrainSchedule } from '../interface.ts';
-import type { MainPageToken, ProxyToken, SearchCore } from '../search_core.ts';
+import type { Fetcher, MainPageToken, ProxyToken, SearchCore } from '../search_core.ts';
 
 class FixedScheduleSearcher implements IFixedScheduleSearcher {
   constructor(
@@ -7,6 +7,10 @@ class FixedScheduleSearcher implements IFixedScheduleSearcher {
     private readonly main: MainPageToken,
     private readonly proxy: ProxyToken,
     private readonly date: Date,
+    // Network proxy for the data fetch (resolved at build time).
+    private readonly netProxy?: string,
+    // Cookie jar the session was built with.
+    private readonly session?: Fetcher,
   ) {}
 
   Search(): Promise<TrainSchedule[]> {
@@ -15,6 +19,9 @@ class FixedScheduleSearcher implements IFixedScheduleSearcher {
       this.proxy.searchData,
       this.proxy.formValidationCode,
       this.date,
+      this.netProxy,
+      false,
+      this.session,
     );
   }
 }

--- a/src/domain/searcher/loaded_schedule_searcher.ts
+++ b/src/domain/searcher/loaded_schedule_searcher.ts
@@ -1,14 +1,24 @@
 import type { From, IScheduleSearcher, TrainSchedule } from '../interface.ts';
-import type { MainPageToken, SearchCore } from '../search_core.ts';
+import type { Fetcher, MainPageToken, SearchCore } from '../search_core.ts';
 
 class LoadedScheduleSearcher implements IScheduleSearcher {
   constructor(
     private readonly searchCore: SearchCore,
     private readonly main: MainPageToken,
+    // Fixed proxy for this stream. Falls back to the random pool when omitted.
+    private readonly proxyOverride?: string,
+    // Rotate a random X-Real-IP per request to dodge the rate limiter.
+    private readonly spoofIp = false,
+    // Fall back to the config proxy pool when no override (legacy); stream
+    // searchers pass false => direct when no proxy.
+    private readonly usePool = false,
+    // The cookie jar the main page was loaded with; reused for every poll so
+    // the session stays consistent.
+    private readonly session?: Fetcher,
   ) {}
 
   async Search(from: From, date: Date): Promise<TrainSchedule[]> {
-    const proxy = this.searchCore.proxy;
+    const proxy = this.proxyOverride ?? (this.usePool ? this.searchCore.proxy : undefined);
     const p = await this.searchCore.proxyKTMBPost(
       from,
       date,
@@ -16,6 +26,8 @@ class LoadedScheduleSearcher implements IScheduleSearcher {
       this.main.WoodlandsToken,
       this.main.requestVerificationToken,
       proxy,
+      this.spoofIp,
+      this.session,
     );
     return await this.searchCore.getData(
       this.main.requestVerificationToken,
@@ -23,6 +35,8 @@ class LoadedScheduleSearcher implements IScheduleSearcher {
       p.formValidationCode,
       date,
       proxy,
+      this.spoofIp,
+      this.session,
     );
   }
 }

--- a/src/domain/searcher/mobile_held_schedule_searcher.ts
+++ b/src/domain/searcher/mobile_held_schedule_searcher.ts
@@ -1,0 +1,41 @@
+import type { From, IScheduleSearcher, TrainSchedule } from '../interface.ts';
+import type { MobileSearchCore, StationMap } from '../mobile_search_core.ts';
+
+/**
+ * Mobile, held: cache `searchData` per route+date and make the steady-state
+ * poll a single Trip call. When Trip fails (stale `searchData`), refresh once
+ * via Search and retry.
+ */
+class MobileHeldScheduleSearcher implements IScheduleSearcher {
+  #stations?: StationMap;
+  #searchData = new Map<string, string>();
+
+  constructor(
+    private readonly core: MobileSearchCore,
+    private readonly userData: string,
+    private readonly proxy?: string,
+    private readonly spoofIp = false,
+  ) {}
+
+  async Search(from: From, date: Date): Promise<TrainSchedule[]> {
+    const key = `${from}:${date.toISOString()}`;
+    let searchData = this.#searchData.get(key) ?? (await this.#refresh(from, date, key));
+
+    try {
+      return await this.core.trip(this.userData, date, searchData, this.proxy, this.spoofIp);
+    } catch {
+      // Most likely a stale searchData — refresh once and retry.
+      searchData = await this.#refresh(from, date, key);
+      return this.core.trip(this.userData, date, searchData, this.proxy, this.spoofIp);
+    }
+  }
+
+  async #refresh(from: From, date: Date, key: string): Promise<string> {
+    if (this.#stations == null) this.#stations = await this.core.stations(this.userData, this.proxy, this.spoofIp);
+    const searchData = await this.core.search(this.userData, from, date, this.#stations, this.proxy, this.spoofIp);
+    this.#searchData.set(key, searchData);
+    return searchData;
+  }
+}
+
+export { MobileHeldScheduleSearcher };

--- a/src/domain/searcher/mobile_stateless_schedule_searcher.ts
+++ b/src/domain/searcher/mobile_stateless_schedule_searcher.ts
@@ -1,0 +1,25 @@
+import type { From, IScheduleSearcher, TrainSchedule } from '../interface.ts';
+import type { MobileSearchCore, StationMap } from '../mobile_search_core.ts';
+
+/**
+ * Mobile, stateless: every poll runs Search then Trip. Stations rarely change,
+ * so they are fetched once and memoised on the instance.
+ */
+class MobileStatelessScheduleSearcher implements IScheduleSearcher {
+  #stations?: StationMap;
+
+  constructor(
+    private readonly core: MobileSearchCore,
+    private readonly userData: string,
+    private readonly proxy?: string,
+    private readonly spoofIp = false,
+  ) {}
+
+  async Search(from: From, date: Date): Promise<TrainSchedule[]> {
+    if (this.#stations == null) this.#stations = await this.core.stations(this.userData, this.proxy, this.spoofIp);
+    const searchData = await this.core.search(this.userData, from, date, this.#stations, this.proxy, this.spoofIp);
+    return this.core.trip(this.userData, date, searchData, this.proxy, this.spoofIp);
+  }
+}
+
+export { MobileStatelessScheduleSearcher };

--- a/src/domain/searcher/stateless_schedule_searcher.ts
+++ b/src/domain/searcher/stateless_schedule_searcher.ts
@@ -2,11 +2,22 @@ import type { From, IScheduleSearcher, TrainSchedule } from '../interface.ts';
 import type { SearchCore } from '../search_core.ts';
 
 class StatelessScheduleSearcher implements IScheduleSearcher {
-  constructor(private readonly searchCore: SearchCore) {}
+  constructor(
+    private readonly searchCore: SearchCore,
+    // Fixed proxy for this stream. Falls back to the random pool when omitted.
+    private readonly proxyOverride?: string,
+    // Rotate a random X-Real-IP per request to dodge the rate limiter.
+    private readonly spoofIp = false,
+    // When no proxy override is set, fall back to the config proxy pool
+    // (legacy). Stream-built searchers pass false => direct when no proxy.
+    private readonly usePool = false,
+  ) {}
 
   async Search(from: From, date: Date): Promise<TrainSchedule[]> {
-    const proxy = this.searchCore.proxy;
-    const main = await this.searchCore.mainKTMBPage(proxy);
+    const proxy = this.proxyOverride ?? (this.usePool ? this.searchCore.proxy : undefined);
+    // Fresh cookie jar per poll — stateless re-establishes the session each time.
+    const session = this.searchCore.newSession();
+    const main = await this.searchCore.mainKTMBPage(proxy, this.spoofIp, session);
     const p = await this.searchCore.proxyKTMBPost(
       from,
       date,
@@ -14,6 +25,8 @@ class StatelessScheduleSearcher implements IScheduleSearcher {
       main.WoodlandsToken,
       main.requestVerificationToken,
       proxy,
+      this.spoofIp,
+      session,
     );
     return await this.searchCore.getData(
       main.requestVerificationToken,
@@ -21,6 +34,8 @@ class StatelessScheduleSearcher implements IScheduleSearcher {
       p.formValidationCode,
       date,
       proxy,
+      this.spoofIp,
+      session,
     );
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,9 +7,13 @@ import { ConfigLoader } from './system/loader.ts';
 import { OtelService } from './system/tracing.ts';
 import { SearcherBuilder } from './domain/searcher/builder.ts';
 import { SearchCore } from './domain/search_core.ts';
+import { MobileSearchCore } from './domain/mobile_search_core.ts';
 import { ZincDate } from './util/zinc_date.ts';
 import { Get } from './lib/get.ts';
 import { Watcher } from './lib/watcher.ts';
+import { Poller } from './lib/poller.ts';
+import { Streamer } from './lib/streamer.ts';
+import { Authenticator } from './lib/authenticator.ts';
 import { loadDescope, loadRedis, loadZinc } from './constructors.ts';
 import { DescopeAuth } from './lib/auth.ts';
 import type { Auth } from './lib/interfaces.ts';
@@ -40,11 +44,15 @@ const descope = loadDescope(cfg.auth.descope);
 const auth: Auth = new DescopeAuth(descope, cfg.auth.descope);
 const zincDate = new ZincDate();
 const searchCore = new SearchCore(cfg.app.searcher, logger);
-const searchBuilder = new SearcherBuilder(searchCore);
+const mobileSearchCore = new MobileSearchCore(cfg.app.searcher, logger);
+const searchBuilder = new SearcherBuilder(searchCore, mobileSearchCore);
 const detailFactory = new DetailFactory(cfg.error, cfg.app);
 const utility = new Utility(detailFactory);
 
 const watcher = new Watcher(cfg.app.watcher, logger, caches.get('live')!, searchBuilder, zincDate);
+const poller = new Poller(logger, caches.get('live')!, zincDate);
+const streamer = new Streamer(logger, searchBuilder, poller);
+const authenticator = new Authenticator(logger, mobileSearchCore);
 const getter = new Get(searchBuilder);
 const zinc = loadZinc(cfg.zinc, auth);
 const checker = new Checker(zinc, utility, zincDate);
@@ -54,6 +62,6 @@ const updater = new Updater(zinc, utility, zincDate, checker, logger, populator)
 const refunder = new Refunder(logger, zinc, utility);
 const reverter = new Reverter(logger, zinc, utility);
 
-const cli = new Cli(logger, cfg, zincDate, watcher, getter, updater, refunder, reverter);
+const cli = new Cli(logger, cfg, zincDate, watcher, getter, updater, refunder, reverter, streamer, authenticator);
 
 await cli.start();

--- a/src/lib/authenticator.ts
+++ b/src/lib/authenticator.ts
@@ -1,0 +1,33 @@
+import { writeFile } from 'node:fs/promises';
+import type { Logger } from 'pino';
+import type { MobileSearchCore } from '../domain/mobile_search_core.ts';
+
+/**
+ * Mints a KTMB `userData` session token via EmailLogin and writes it to a file
+ * for the stream/bench commands to consume.
+ *
+ * KTMB allows only one active session per account, so a fresh login invalidates
+ * any previous token. This is the single, explicit place helium logs in.
+ */
+class Authenticator {
+  constructor(
+    private readonly logger: Logger,
+    private readonly mobileCore: MobileSearchCore,
+  ) {}
+
+  async Login(email: string, password: string, out: string, proxy?: string): Promise<string> {
+    this.logger.info({ email, out }, 'Logging in to KTMB');
+    const res = await this.mobileCore.login(email, password, proxy);
+
+    // 0o600: the token is a live session credential — keep it owner-only.
+    await writeFile(out, `${res.userData}\n`, { mode: 0o600 });
+
+    this.logger.info(
+      { email: res.email, fullName: res.fullName, eWallet: res.eWalletAmount, out },
+      'Logged in; token written',
+    );
+    return res.userData;
+  }
+}
+
+export { Authenticator };

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -42,14 +42,14 @@ class Poller {
         const sch = await searcher.Search(from, d);
         const timing: Record<string, number> = {};
         for (const s of sch) timing[s.departure_time] = s.available_seats;
-        // The fetch succeeded — surface the schedule regardless of redis.
-        this.logger.info({ label, key, timing }, 'Polled schedule');
         polls++;
         failureCount = 0;
 
-        // Publishing is best-effort: a redis outage must not be treated as a
-        // poll failure (we already have the data). Skip entirely on dry-run.
-        if (!dryRun) {
+        // dry-run: surface the schedule (testing). Production: just publish —
+        // per-poll logging is expensive at high poll rates.
+        if (dryRun) {
+          this.logger.info({ label, key, timing }, 'Polled schedule (dry-run)');
+        } else {
           try {
             await this.redis.publish(key, JSON.stringify(timing));
           } catch (e) {

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -1,0 +1,76 @@
+import type { Logger } from 'pino';
+import type Redis from 'ioredis';
+import type { From, IScheduleSearcher } from '../domain/interface.ts';
+import type { ZincDate } from '../util/zinc_date.ts';
+
+/**
+ * Runs a single stream: repeatedly polls one searcher against a fixed
+ * date+direction, publishing availability to redis, until the run duration
+ * elapses. Pacing is the stream's own `delayMs`. Injected dependencies keep it
+ * unit-testable with a mock searcher and redis.
+ */
+class Poller {
+  constructor(
+    private readonly logger: Logger,
+    private readonly redis: Redis,
+    private readonly zincDate: ZincDate,
+  ) {}
+
+  async Poll(
+    searcher: IScheduleSearcher,
+    label: string,
+    d: Date,
+    from: From,
+    startTime: number,
+    durationMs: number,
+    delayMs: number,
+    // When true, log the fetched schedule instead of publishing to redis.
+    // Useful for local testing where `live` redis is unreachable.
+    dryRun = false,
+  ): Promise<void> {
+    const od = this.zincDate.to(d);
+    const key = `ktmb:schedule:${from}:${od}`;
+
+    let failureCount = 0;
+    let polls = 0;
+
+    while (true) {
+      const elapsed = Date.now() - startTime;
+      if (elapsed >= durationMs) break;
+
+      try {
+        const sch = await searcher.Search(from, d);
+        const timing: Record<string, number> = {};
+        for (const s of sch) timing[s.departure_time] = s.available_seats;
+        // The fetch succeeded — surface the schedule regardless of redis.
+        this.logger.info({ label, key, timing }, 'Polled schedule');
+        polls++;
+        failureCount = 0;
+
+        // Publishing is best-effort: a redis outage must not be treated as a
+        // poll failure (we already have the data). Skip entirely on dry-run.
+        if (!dryRun) {
+          try {
+            await this.redis.publish(key, JSON.stringify(timing));
+          } catch (e) {
+            this.logger.warn({ err: e, label, key }, 'Failed to publish schedule to redis');
+          }
+        }
+      } catch (e) {
+        const message = e instanceof Error ? e.message : String(e);
+        this.logger.error({ err: e, label, message }, 'Failed to poll schedule');
+        failureCount++;
+        if (failureCount > 10) {
+          this.logger.error({ label }, 'Failed to poll schedule too many times, stopping poller');
+          break;
+        }
+      }
+
+      await new Promise(resolve => setTimeout(resolve, delayMs));
+    }
+
+    this.logger.info({ label, polls }, 'Poller complete');
+  }
+}
+
+export { Poller };

--- a/src/lib/streamer.ts
+++ b/src/lib/streamer.ts
@@ -1,0 +1,43 @@
+import type { Logger } from 'pino';
+import type { SearcherBuilder } from '../domain/searcher/builder.ts';
+import type { From, StreamSpec } from '../domain/interface.ts';
+import type { Poller } from './poller.ts';
+
+// One polling stream: a transport/mode config bound to a date + direction.
+interface WatchEntry {
+  d: Date;
+  from: From;
+  spec: StreamSpec;
+}
+
+/**
+ * Runs the deterministic poller table: builds one searcher per entry and runs
+ * them all in parallel, each against its own date+direction with its own
+ * proxy/delay/spoof. One failing stream never kills the others.
+ */
+class Streamer {
+  constructor(
+    private readonly logger: Logger,
+    private readonly builder: SearcherBuilder,
+    private readonly poller: Poller,
+  ) {}
+
+  async Run(entries: WatchEntry[], startTime: number, durationMs: number, dryRun = false): Promise<void> {
+    this.logger.info({ count: entries.length, dryRun }, 'Starting streams');
+
+    const all = entries.map(async (e, idx) => {
+      const label = `${e.spec.mode}/${e.spec.type}:${e.from}#${idx}`;
+      try {
+        const searcher = await this.builder.BuildForStream(e.spec);
+        await this.poller.Poll(searcher, label, e.d, e.from, startTime, durationMs, e.spec.delay, dryRun);
+      } catch (err) {
+        this.logger.error({ err, label }, 'Stream failed to start');
+      }
+    });
+
+    await Promise.allSettled(all);
+    this.logger.info({ count: entries.length }, 'Streams complete');
+  }
+}
+
+export { type WatchEntry, Streamer };

--- a/src/util/random_ip.ts
+++ b/src/util/random_ip.ts
@@ -1,0 +1,4 @@
+// Random IPv4 for the X-Real-IP header. KTMB's rate limiter keys on the
+// client-supplied X-Real-IP, so a fresh value per request rotates the bucket.
+export const randomIp = (): string =>
+  `${1 + Math.floor(Math.random() * 222)}.${Math.floor(Math.random() * 256)}.${Math.floor(Math.random() * 256)}.${1 + Math.floor(Math.random() * 254)}`;


### PR DESCRIPTION
## Summary

Reworks the pollee around a **deterministic stream table**. Headline additions: a **mobile** transport, opt-in **X-Real-IP spoofing**, and per-stream **held/stateless** choice — plus the interface and concurrency changes needed to run many streams.

## What changed

**New capabilities**
- **Mobile transport** — `MobileSearchCore` (KTMB mobile JSON API) + held/stateless mobile searchers, alongside the existing web scrape path.
- **`login` command + `Authenticator`** — mints a `userData` token to a file; helium never logs in during polling.
- **X-Real-IP spoofing** (`spoofIp`, opt-in) — rotates a random `X-Real-IP` per request. KTMB's IIS/ASP.NET limiter keys on that header (~100–130 req/min per IP per endpoint), so rotating it bypasses the limit. Verified on both web and mobile.
- **Per-stream `proxy`** — `"<url>"` = that proxy, `true` = config pool, omit/`false` = direct.
- **Per-stream `mode` (web|mobile), `type` (stateless|held), `delay`**.

**Interface**
- `multi-watch` now takes **targets × settings**: `-d '[{date,from}]'` × `-s '[{mode,type,delay,proxy,spoofIp,token}]'`. Each pair is one parallel poller publishing to `ktmb:schedule:<dir>:<date>` (unchanged downstream). N targets × M settings = N×M streams.
- Removed the interim `stream`/`bench` commands (folded into `multi-watch`).

**Scale/perf**
- **Isolated cookie jars per web session** (`SearchCore.newSession`) so concurrent web streams don't collide on a shared antiforgery/session jar. Verified with concurrent web streams.
- Proxy-pool fallback moved out of `SearchCore` into the searchers (`usePool`), keeping legacy `watch`/`schedule`/`get` on the pool while stream-built searchers are explicit (default direct).

## Notes
- `config/app/searcher.requestSignature` is committed empty — inject the real value via the existing secret/env at runtime (mirrors tin).
- Local secrets/scratch (`ktmb.token`, `proxy.txt`, `*.csv`) are gitignored.

## Test
- `tsc` clean on all changed files (pre-existing `zinc/http-client.ts` errors untouched); biome clean.
- Verified live from an SG box: web + mobile polling, held/stateless, proxy on/off, `spoofIp` bypass, the targets×settings cross product, and concurrent web streams.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Mobile KTMB API support for schedule searches with optional authentication
  * New login command to obtain and save user tokens
  * multi-watch: run concurrent polling streams with configurable modes (web/mobile), types (stateless/held), per-stream delay, proxy and optional IP spoofing
  * Streams publish availability updates to Redis

* **Chores**
  * Configuration schema and defaults extended to support searcher/stream settings
  * Updated .gitignore to exclude local secret/scratch files and CSVs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->