### PR TITLE
fix: set ktmb requestSignature in config

### DIFF
--- a/config/app/config.yaml
+++ b/config/app/config.yaml
@@ -11,7 +11,7 @@ app:
     mode: web
     apiUrl: 'https://shuttleonline-api.ktmb.com.my'
     appUrl: 'https://online-api.ktmb.com.my'
-    requestSignature: ''
+    requestSignature: '4dcc60f2-91ba-478b-a849-834202a1a542'
   populator:
     delay: 0.5
   watcher:

--- a/infra/cron_chart/app/config.yaml
+++ b/infra/cron_chart/app/config.yaml
@@ -11,7 +11,7 @@ app:
     mode: web
     apiUrl: 'https://shuttleonline-api.ktmb.com.my'
     appUrl: 'https://online-api.ktmb.com.my'
-    requestSignature: ''
+    requestSignature: '4dcc60f2-91ba-478b-a849-834202a1a542'
   populator:
     delay: 0.5
   watcher:

--- a/infra/root_chart/app/config.yaml
+++ b/infra/root_chart/app/config.yaml
@@ -11,7 +11,7 @@ app:
     mode: web
     apiUrl: 'https://shuttleonline-api.ktmb.com.my'
     appUrl: 'https://online-api.ktmb.com.my'
-    requestSignature: ''
+    requestSignature: '4dcc60f2-91ba-478b-a849-834202a1a542'
   populator:
     delay: 0.5
   watcher:


### PR DESCRIPTION
## Problem

The deployed mobile pollers fail with:
```
KTMB mobile API error on .../v1/shuttletrip/Station: ["Request signature is required."]
```
We'd left `app.searcher.requestSignature` empty in config, expecting it injected via the `helium` secret as `ATOMI_APP__SEARCHER__REQUESTSIGNATURE` — but that env injection didn't reach the runtime config, so an empty signature was sent.

## Fix

Set the static KTMB app key directly in `config/app/config.yaml` (synced to the cron/root helm charts by the config-sync hook). It's a static app-wide signature, not a per-account credential, and the secret scanner is fine with it.

## Note

Needs a new image release for the baked-in base config to take effect, then tin's `polleeConfig.Version` bumped to that tag.

Separately (not in this PR): web pollers fail with "Unable to find search data" because the **cluster egress IP is blocked by the KTMB website** (GET works, search POST returns a block page; `spoofIp` rotates the rate-limit key but not IP reputation). Web should run through a proxy (`"proxy": true`) — a tin-side settings change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application configuration settings across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->