### PR TITLE
feat: print per-stream poll tally at end of multi-watch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,7 +51,7 @@ const utility = new Utility(detailFactory);
 
 const watcher = new Watcher(cfg.app.watcher, logger, caches.get('live')!, searchBuilder, zincDate);
 const poller = new Poller(logger, caches.get('live')!, zincDate);
-const streamer = new Streamer(logger, searchBuilder, poller);
+const streamer = new Streamer(logger, searchBuilder, poller, zincDate);
 const authenticator = new Authenticator(logger, mobileSearchCore);
 const getter = new Get(searchBuilder);
 const zinc = loadZinc(cfg.zinc, auth);

--- a/src/lib/poller.ts
+++ b/src/lib/poller.ts
@@ -27,12 +27,13 @@ class Poller {
     // When true, log the fetched schedule instead of publishing to redis.
     // Useful for local testing where `live` redis is unreachable.
     dryRun = false,
-  ): Promise<void> {
+  ): Promise<{ polls: number; fails: number }> {
     const od = this.zincDate.to(d);
     const key = `ktmb:schedule:${from}:${od}`;
 
     let failureCount = 0;
     let polls = 0;
+    let fails = 0;
 
     while (true) {
       const elapsed = Date.now() - startTime;
@@ -60,6 +61,7 @@ class Poller {
         const message = e instanceof Error ? e.message : String(e);
         this.logger.error({ err: e, label, message }, 'Failed to poll schedule');
         failureCount++;
+        fails++;
         if (failureCount > 10) {
           this.logger.error({ label }, 'Failed to poll schedule too many times, stopping poller');
           break;
@@ -69,7 +71,8 @@ class Poller {
       await new Promise(resolve => setTimeout(resolve, delayMs));
     }
 
-    this.logger.info({ label, polls }, 'Poller complete');
+    this.logger.info({ label, polls, fails }, 'Poller complete');
+    return { polls, fails };
   }
 }
 

--- a/src/lib/streamer.ts
+++ b/src/lib/streamer.ts
@@ -70,12 +70,19 @@ class Streamer {
       }),
     );
 
-    const totalPolls = tallies.reduce((acc, t) => acc + t.polls, 0);
-    const totalFails = tallies.reduce((acc, t) => acc + t.fails, 0);
-    this.logger.info(
-      { streams: tallies, totalPolls, totalFails, count: tallies.length },
-      'multi-watch summary: polls per date/direction/type',
-    );
+    // One flat log line per stream (LogQL parses flat fields, not arrays),
+    // then a totals line.
+    let totalPolls = 0;
+    let totalFails = 0;
+    for (const t of tallies) {
+      totalPolls += t.polls;
+      totalFails += t.fails;
+      this.logger.info(
+        { date: t.date, from: t.from, mode: t.mode, type: t.type, polls: t.polls, fails: t.fails },
+        'multi-watch stream summary',
+      );
+    }
+    this.logger.info({ count: tallies.length, totalPolls, totalFails }, 'multi-watch total summary');
   }
 }
 

--- a/src/lib/streamer.ts
+++ b/src/lib/streamer.ts
@@ -1,6 +1,7 @@
 import type { Logger } from 'pino';
 import type { SearcherBuilder } from '../domain/searcher/builder.ts';
 import type { From, StreamSpec } from '../domain/interface.ts';
+import type { ZincDate } from '../util/zinc_date.ts';
 import type { Poller } from './poller.ts';
 
 // One polling stream: a transport/mode config bound to a date + direction.
@@ -10,34 +11,72 @@ interface WatchEntry {
   spec: StreamSpec;
 }
 
+// Per-stream tally printed at the end so we can confirm polling happened.
+interface StreamTally {
+  date: string;
+  from: From;
+  mode: StreamSpec['mode'];
+  type: StreamSpec['type'];
+  polls: number;
+  fails: number;
+}
+
 /**
  * Runs the deterministic poller table: builds one searcher per entry and runs
  * them all in parallel, each against its own date+direction with its own
- * proxy/delay/spoof. One failing stream never kills the others.
+ * proxy/delay/spoof. One failing stream never kills the others. At the end
+ * (whether streams succeeded, failed, or gave up) it prints a per-stream poll
+ * tally so we can verify each date/direction/transport was polling.
  */
 class Streamer {
   constructor(
     private readonly logger: Logger,
     private readonly builder: SearcherBuilder,
     private readonly poller: Poller,
+    private readonly zincDate: ZincDate,
   ) {}
 
   async Run(entries: WatchEntry[], startTime: number, durationMs: number, dryRun = false): Promise<void> {
     this.logger.info({ count: entries.length, dryRun }, 'Starting streams');
 
-    const all = entries.map(async (e, idx) => {
-      const label = `${e.spec.mode}/${e.spec.type}:${e.from}#${idx}`;
-      try {
-        const searcher = await this.builder.BuildForStream(e.spec);
-        await this.poller.Poll(searcher, label, e.d, e.from, startTime, durationMs, e.spec.delay, dryRun);
-      } catch (err) {
-        this.logger.error({ err, label }, 'Stream failed to start');
-      }
-    });
+    const tallies = await Promise.all(
+      entries.map(async (e, idx) => {
+        const label = `${e.spec.mode}/${e.spec.type}:${e.from}#${idx}`;
+        const base: StreamTally = {
+          date: this.zincDate.to(e.d),
+          from: e.from,
+          mode: e.spec.mode,
+          type: e.spec.type,
+          polls: 0,
+          fails: 0,
+        };
+        try {
+          const searcher = await this.builder.BuildForStream(e.spec);
+          const { polls, fails } = await this.poller.Poll(
+            searcher,
+            label,
+            e.d,
+            e.from,
+            startTime,
+            durationMs,
+            e.spec.delay,
+            dryRun,
+          );
+          return { ...base, polls, fails };
+        } catch (err) {
+          this.logger.error({ err, label }, 'Stream failed to start');
+          return base;
+        }
+      }),
+    );
 
-    await Promise.allSettled(all);
-    this.logger.info({ count: entries.length }, 'Streams complete');
+    const totalPolls = tallies.reduce((acc, t) => acc + t.polls, 0);
+    const totalFails = tallies.reduce((acc, t) => acc + t.fails, 0);
+    this.logger.info(
+      { streams: tallies, totalPolls, totalFails, count: tallies.length },
+      'multi-watch summary: polls per date/direction/type',
+    );
   }
 }
 
-export { type WatchEntry, Streamer };
+export { type WatchEntry, type StreamTally, Streamer };


### PR DESCRIPTION
## Summary

At the end of every `multi-watch` run, log a per-stream tally of how many polls each `(date, direction, mode/type)` did — so we can confirm from logs that polling actually happened.

- `Poller.Poll` now returns `{ polls, fails }` (it already counted them internally).
- `Streamer.Run` collects each stream's counts and emits a final structured log:
  ```
  msg: "multi-watch summary: polls per date/direction/type"
  streams: [{ date, from, mode, type, polls, fails }, ...]
  totalPolls, totalFails, count
  ```
- Fires regardless of outcome — success, per-poll failures, or a stream that hit the give-up cap (e.g. a blocked web stream shows `polls: 0, fails: 11`). Streams that fail to even build are included with `polls: 0`.
- `Streamer` now takes `ZincDate` to render the date as `dd-mm-yyyy`.

## Test

Verified live: 2 dates × (web + mobile) → 4 entries in the summary array with correct date/from/mode/type and poll counts; `tsc`/biome clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Polling now produces detailed statistics for attempts and failures.
  * End-of-run reports show per-stream tallies (date, source, mode, type, polls, fails) plus an overall aggregate summary.

* **Refactor**
  * Stream polling was refactored to run entries in parallel with improved error handling so each entry always yields a tally and summaries are consistently emitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->